### PR TITLE
Fix typo in Bluetooth printer doc

### DIFF
--- a/app/docs/react-native-bluetooth-escpos-printer.md
+++ b/app/docs/react-native-bluetooth-escpos-printer.md
@@ -341,7 +341,7 @@ await  BluetoothEscposPrinter.printText("广州俊烨\n\r",{
   encoding:'GBK',
   codepage:0,
   widthtimes:3,
-  heigthtimes:3,
+  heighttimes:3,
   fonttype:1
 });
 await BluetoothEscposPrinter.setBlob(0);
@@ -349,7 +349,7 @@ await  BluetoothEscposPrinter.printText("销售单\n\r",{
   encoding:'GBK',
   codepage:0,
   widthtimes:0,
-  heigthtimes:0,
+  heighttimes:0,
   fonttype:1
 });
 await BluetoothEscposPrinter.printerAlign(BluetoothEscposPrinter.ALIGN.LEFT);


### PR DESCRIPTION
## Summary
- correct typo `heigthtimes` to `heighttimes` in Bluetooth printer README

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406390baf4832eb90d6decf4a185cf